### PR TITLE
dubug train.py when training with mutipule nodes

### DIFF
--- a/train.py
+++ b/train.py
@@ -165,7 +165,7 @@ def main(args):
 
     requires_grad(ema, False)
     
-    model = DDP(model.to(device), device_ids=[rank])
+    model = DDP(model.to(device), device_ids=[device])
     transport = create_transport(
         args.path_type,
         args.prediction,


### PR DESCRIPTION
When using multiple nodes for training, the rank will be greater than the number of GPUs on each node, resulting in an error: stream = _get_stream(target_device) indexerror: list index out of range