### PR TITLE
Fix backward ODE integration

### DIFF
--- a/transport/integrators.py
+++ b/transport/integrators.py
@@ -87,8 +87,6 @@ class ode:
         atol,
         rtol,
     ):
-        assert t0 < t1, "ODE sampler has to be in forward time"
-
         self.drift = drift
         self.t = th.linspace(t0, t1, num_steps)
         self.atol = atol

--- a/transport/transport.py
+++ b/transport/transport.py
@@ -357,10 +357,7 @@ class Sampler:
         - rtol: relative error tolerance for the solver
         - reverse: whether solving the ODE in reverse (data to noise); default to False
         """
-        if reverse:
-            drift = lambda x, t, model, **kwargs: self.drift(x, th.ones_like(t) * (1 - t), model, **kwargs)
-        else:
-            drift = self.drift
+        drift = self.drift
 
         t0, t1 = self.transport.check_interval(
             self.transport.train_eps,


### PR DESCRIPTION
Reverse ODE integration is currently broken.

In torchdiffeq, reverse integration is achieved by providing time arguments in [decreasing order](https://github.com/rtqichen/torchdiffeq/blob/f3135f371ae827526cc7db498b7058d597108efb/torchdiffeq/_impl/odeint.py#L53). This is already achieved in the `transport.check_interval(...)` function. Therefore, reversing the time in the drift function is unnecessary, leading to wrong results.